### PR TITLE
Pull Docker images from Nexus instead of Quay

### DIFF
--- a/git-server/openshift/gogs.json
+++ b/git-server/openshift/gogs.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -54,6 +54,13 @@
       "description": "The name of the docker image to pull",
       "required": true,
       "value": "registry"
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
+      "required": true,
+      "value": ""
     },
     {
       "name": "INSECURE_REPOSITORY",
@@ -172,6 +179,11 @@
                   }
                 },
                 "terminationMessagePath": "/dev/termination-log"
+              }
+            ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
               }
             ],
             "dnsPolicy": "ClusterFirst",

--- a/git-server/openshift/gogs.json
+++ b/git-server/openshift/gogs.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/jenkins/openshift/credentials-list.txt
+++ b/jenkins/openshift/credentials-list.txt
@@ -3,7 +3,7 @@ elasticsearch: Elasticsearch credentials
 nexusCredentials: Nexus admin credentials
 jenkinsCredentials: CICD Jenkins
 cicdGithub: Github credentials for CICD checkout
-dockerCredentials: Credentials for pushing to quay
+dockerCredentials: Credentials for pushing to Nexus
 curlCredentials: Creds used for various curl commands, such as removeRaster
 mavenCredentials: Credentials for our Maven server (e.i. Nexus username and password)
 o2-artifact-project: ossim-ci The path for the o2 artifacts project

--- a/nexus/README.md
+++ b/nexus/README.md
@@ -11,7 +11,7 @@ Therefore, once nexus.repo is used, the other files in `/etc/yum.repos.d/` can s
 
 # Responsibilities
 
-Nexus is the de facto location for O2 project dependency related artifacts except docker images, which are stored in Quay. 
+Nexus is the de facto location for O2 project dependency related artifacts including docker images. 
 Specifically, Nexus serves as the maven repository (used by Gradle) and Yum repository.
  
 

--- a/nexus/openshift/nexus-template.json
+++ b/nexus/openshift/nexus-template.json
@@ -260,6 +260,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "volumes": [
@@ -429,7 +434,7 @@
       "description": "The Docker Registry the ImageStream will pull from.",
       "displayName": "Nexus ImageStream Namespace",
       "name": "DOCKER_REGISTRY",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "The Route that will redirect to Nexus",
@@ -454,6 +459,13 @@
       "displayName": "Nexus Image Name",
       "name": "NEXUS_IMAGE_NAME",
       "value": "nexus3"
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
+      "required": true,
+      "value": ""
     },
     {
       "description": "Tag of the Image to be used for the Nexus image.",

--- a/nexus/openshift/nexus-template.json
+++ b/nexus/openshift/nexus-template.json
@@ -417,7 +417,7 @@
       "description": "The EBS volume ID",
       "displayName": "EBS Volume ID",
       "name": "EBS_VOLUME_ID",
-      "required": true,
+      "required": true
     },
     {
       "description": "The OpenShift Namespace where the Nexus ImageStream resides.",
@@ -429,7 +429,7 @@
       "description": "The Docker Registry the ImageStream will pull from.",
       "displayName": "Nexus ImageStream Namespace",
       "name": "DOCKER_REGISTRY",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "The Route that will redirect to Nexus",

--- a/omar/compose/docker-compose-proxy.yml
+++ b/omar/compose/docker-compose-proxy.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   omar-web-proxy-app:
-    image: quay.io/radiantsolutions/omar-web-proxy-app:latest
+    image: nexus-docker-public-hosted.ossim.io/omar-web-proxy-app:latest
     ports:
       - 80:80
       - 443:443

--- a/omar/openshift/templates/apps/icarus-app.json
+++ b/omar/openshift/templates/apps/icarus-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/icarus-app.json
+++ b/omar/openshift/templates/apps/icarus-app.json
@@ -197,6 +197,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/icarus-app.json
+++ b/omar/openshift/templates/apps/icarus-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/icarus-app.json
+++ b/omar/openshift/templates/apps/icarus-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/isa-ui-app.json
+++ b/omar/openshift/templates/apps/isa-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/isa-ui-app.json
+++ b/omar/openshift/templates/apps/isa-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/isa-ui-app.json
+++ b/omar/openshift/templates/apps/isa-ui-app.json
@@ -210,6 +210,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/isa-ui-app.json
+++ b/omar/openshift/templates/apps/isa-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/nifi-cluster.json
+++ b/omar/openshift/templates/apps/nifi-cluster.json
@@ -234,7 +234,7 @@
                                         "value": "yes"
                                     }
                                 ],
-                                "image": "nexus-docker-public-group.ossim.io/zookeeper",
+                                "image": "nexus-docker-private-group.ossim.io/zookeeper",
                                 "imagePullPolicy": "Always",
                                 "name": "zookeeper",
                                 "ports": [

--- a/omar/openshift/templates/apps/nifi-cluster.json
+++ b/omar/openshift/templates/apps/nifi-cluster.json
@@ -234,7 +234,7 @@
                                         "value": "yes"
                                     }
                                 ],
-                                "image": "nexus-docker-public-hosted.ossim.io/zookeeper",
+                                "image": "nexus-docker-public-group.ossim.io/zookeeper",
                                 "imagePullPolicy": "Always",
                                 "name": "zookeeper",
                                 "ports": [

--- a/omar/openshift/templates/apps/nifi-cluster.json
+++ b/omar/openshift/templates/apps/nifi-cluster.json
@@ -21,6 +21,13 @@
             "description": "Persistent volume storage base name",
             "required": true,
             "value": "ossim-data"
+          },
+          {
+            "name": "IMAGE_PULL_SECRET",
+            "displayName": "IMAGE_PULL_SECRET",
+            "description": "The name of the secret to use for pulling docker images from an external registry",
+            "required": true,
+            "value": ""
           }
     ],
     "objects": [
@@ -259,6 +266,11 @@
                                 "terminationMessagePath": "/dev/termination-log",
                                 "terminationMessagePolicy": "File"
                             }
+                        ],
+                        "imagePullSecrets": [
+                          {
+                            "name": "${IMAGE_PULL_SECRET}"
+                          }
                         ],
                         "dnsPolicy": "ClusterFirst",
                         "restartPolicy": "Always",

--- a/omar/openshift/templates/apps/nifi-cluster.json
+++ b/omar/openshift/templates/apps/nifi-cluster.json
@@ -234,7 +234,7 @@
                                         "value": "yes"
                                     }
                                 ],
-                                "image": "quay.io/radiantsolutions/zookeeper",
+                                "image": "nexus-docker-public-hosted.ossim.io/zookeeper",
                                 "imagePullPolicy": "Always",
                                 "name": "zookeeper",
                                 "ports": [

--- a/omar/openshift/templates/apps/omar-admin-server.json
+++ b/omar/openshift/templates/apps/omar-admin-server.json
@@ -11,7 +11,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-admin-server.json
+++ b/omar/openshift/templates/apps/omar-admin-server.json
@@ -11,7 +11,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -51,6 +51,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-admin-server.json
+++ b/omar/openshift/templates/apps/omar-admin-server.json
@@ -188,6 +188,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-admin-server.json
+++ b/omar/openshift/templates/apps/omar-admin-server.json
@@ -11,7 +11,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-avro-metadata.json
+++ b/omar/openshift/templates/apps/omar-avro-metadata.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-avro-metadata.json
+++ b/omar/openshift/templates/apps/omar-avro-metadata.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-avro-metadata.json
+++ b/omar/openshift/templates/apps/omar-avro-metadata.json
@@ -199,6 +199,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-avro-metadata.json
+++ b/omar/openshift/templates/apps/omar-avro-metadata.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-basemap.json
+++ b/omar/openshift/templates/apps/omar-basemap.json
@@ -179,6 +179,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-basemap.json
+++ b/omar/openshift/templates/apps/omar-basemap.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-basemap.json
+++ b/omar/openshift/templates/apps/omar-basemap.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-basemap.json
+++ b/omar/openshift/templates/apps/omar-basemap.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -196,11 +196,6 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
-            "imagePullSecrets": [
-              {
-                "name": "${IMAGE_PULL_SECRET}"
-              }
-            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-private-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -196,6 +196,11 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-private-hosted.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-blink.json
+++ b/omar/openshift/templates/apps/omar-blink.json
@@ -63,16 +63,16 @@
       "value": ""
     },
     {
-      "name": "INSECURE_REPOSITORY",
-      "displayName": "INSECURE_REPOSITORY",
-      "description": "Mark the image stream as an insecure repository",
-      "value": "false"
-    },
-    {
       "name": "IMAGE_PULL_SECRET",
       "displayName": "IMAGE_PULL_SECRET",
       "description": "The name of the secret to use for pulling docker images from an external registry",
       "value": "registry-creds"
+    },
+    {
+      "name": "INSECURE_REPOSITORY",
+      "displayName": "INSECURE_REPOSITORY",
+      "description": "Mark the image stream as an insecure repository",
+      "value": "false"
     },
     {
       "name": "MEMORY_MIN",

--- a/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-buil.json
@@ -192,6 +192,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
@@ -188,6 +188,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
+++ b/omar/openshift/templates/apps/omar-cesium-terrain-serv.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -196,17 +196,17 @@
                   }
                 },
                 "terminationMessagePath": "/dev/termination-log",
-                "imagePullSecrets": [
-                  {
-                    "name": "${IMAGE_PULL_SECRET}"
-                  }
-                ],
                 "volumeMounts": [
                   {
                     "mountPath": "/home/omar/configs",
                     "name": "spring-config"
                   }
                 ]
+              }
+            ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
               }
             ],
             "dnsPolicy": "ClusterFirst",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -196,6 +196,11 @@
                   }
                 },
                 "terminationMessagePath": "/dev/termination-log",
+                "imagePullSecrets": [
+                  {
+                    "name": "${IMAGE_PULL_SECRET}"
+                  }
+                ],
                 "volumeMounts": [
                   {
                     "mountPath": "/home/omar/configs",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -209,6 +209,11 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -49,17 +49,17 @@
       "value": "1"
     },
     {
+      "name": "INSECURE_REPOSITORY",
+      "displayName": "INSECURE_REPOSITORY",
+      "description": "Mark the image stream as an insecure repository",
+      "value": "false"
+    },
+    {
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
       "required": true,
       "value": ""
-    },
-    {
-      "name": "INSECURE_REPOSITORY",
-      "displayName": "INSECURE_REPOSITORY",
-      "description": "Mark the image stream as an insecure repository",
-      "value": "false"
     },
     {
       "name": "MEMORY_MIN",

--- a/omar/openshift/templates/apps/omar-config-server.json
+++ b/omar/openshift/templates/apps/omar-config-server.json
@@ -49,17 +49,24 @@
       "value": "1"
     },
     {
-      "name": "INSECURE_REPOSITORY",
-      "displayName": "INSECURE_REPOSITORY",
-      "description": "Mark the image stream as an insecure repository",
-      "value": "false"
-    },
-    {
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
       "required": true,
       "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "INSECURE_REPOSITORY",
+      "displayName": "INSECURE_REPOSITORY",
+      "description": "Mark the image stream as an insecure repository",
+      "value": "false"
     },
     {
       "name": "MEMORY_MIN",
@@ -202,11 +209,6 @@
                     "name": "spring-config"
                   }
                 ]
-              }
-            ],
-            "imagePullSecrets": [
-              {
-                "name": "${IMAGE_PULL_SECRET}"
               }
             ],
             "imagePullSecrets": [

--- a/omar/openshift/templates/apps/omar-cucumber-backend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-backend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-backend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-backend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-backend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-backend-test.json
@@ -180,6 +180,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-cucumber-backend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-backend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
@@ -180,6 +180,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-frontend-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
@@ -180,6 +180,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
+++ b/omar/openshift/templates/apps/omar-cucumber-ingest-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-disk-cleanup-app.json
+++ b/omar/openshift/templates/apps/omar-disk-cleanup-app.json
@@ -187,6 +187,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-disk-cleanup-app.json
+++ b/omar/openshift/templates/apps/omar-disk-cleanup-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-disk-cleanup-app.json
+++ b/omar/openshift/templates/apps/omar-disk-cleanup-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-disk-cleanup-app.json
+++ b/omar/openshift/templates/apps/omar-disk-cleanup-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-docs-app.json
+++ b/omar/openshift/templates/apps/omar-docs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-docs-app.json
+++ b/omar/openshift/templates/apps/omar-docs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-docs-app.json
+++ b/omar/openshift/templates/apps/omar-docs-app.json
@@ -193,6 +193,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-docs-app.json
+++ b/omar/openshift/templates/apps/omar-docs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-download-app.json
+++ b/omar/openshift/templates/apps/omar-download-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-download-app.json
+++ b/omar/openshift/templates/apps/omar-download-app.json
@@ -221,6 +221,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-download-app.json
+++ b/omar/openshift/templates/apps/omar-download-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-download-app.json
+++ b/omar/openshift/templates/apps/omar-download-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-eureka-server.json
+++ b/omar/openshift/templates/apps/omar-eureka-server.json
@@ -201,6 +201,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-eureka-server.json
+++ b/omar/openshift/templates/apps/omar-eureka-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-eureka-server.json
+++ b/omar/openshift/templates/apps/omar-eureka-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-eureka-server.json
+++ b/omar/openshift/templates/apps/omar-eureka-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-geoscript-app.json
+++ b/omar/openshift/templates/apps/omar-geoscript-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-geoscript-app.json
+++ b/omar/openshift/templates/apps/omar-geoscript-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-geoscript-app.json
+++ b/omar/openshift/templates/apps/omar-geoscript-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-geoscript-app.json
+++ b/omar/openshift/templates/apps/omar-geoscript-app.json
@@ -229,6 +229,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-jpip-app.json
+++ b/omar/openshift/templates/apps/omar-jpip-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-jpip-app.json
+++ b/omar/openshift/templates/apps/omar-jpip-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-jpip-app.json
+++ b/omar/openshift/templates/apps/omar-jpip-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-jpip-app.json
+++ b/omar/openshift/templates/apps/omar-jpip-app.json
@@ -190,6 +190,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
+++ b/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
@@ -56,16 +56,16 @@
       "value": ""
     },
     {
-      "name": "INSECURE_REPOSITORY",
-      "displayName": "INSECURE_REPOSITORY",
-      "description": "Mark the image stream as an insecure repository",
-      "value": "false"
-    },
-    {
       "name": "IMAGE_PULL_SECRET",
       "displayName": "IMAGE_PULL_SECRET",
       "description": "The name of the secret to use for pulling docker images from an external registry",
       "value": "registry-creds"
+    },
+    {
+      "name": "INSECURE_REPOSITORY",
+      "displayName": "INSECURE_REPOSITORY",
+      "description": "Mark the image stream as an insecure repository",
+      "value": "false"
     },
     {
       "name": "MEMORY_MIN",

--- a/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
+++ b/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-private-hosted.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
+++ b/omar/openshift/templates/apps/omar-kibana-dashboard-test.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-private-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-mapproxy.json
+++ b/omar/openshift/templates/apps/omar-mapproxy.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-mapproxy.json
+++ b/omar/openshift/templates/apps/omar-mapproxy.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-mapproxy.json
+++ b/omar/openshift/templates/apps/omar-mapproxy.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-mapproxy.json
+++ b/omar/openshift/templates/apps/omar-mapproxy.json
@@ -197,6 +197,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-mensa-app.json
+++ b/omar/openshift/templates/apps/omar-mensa-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-mensa-app.json
+++ b/omar/openshift/templates/apps/omar-mensa-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-mensa-app.json
+++ b/omar/openshift/templates/apps/omar-mensa-app.json
@@ -223,6 +223,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-mensa-app.json
+++ b/omar/openshift/templates/apps/omar-mensa-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -309,11 +309,6 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
-            "imagePullSecrets": [
-              {
-                "name": "${IMAGE_PULL_SECRET}"
-              }
-            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -175,17 +175,17 @@
       "value": ""
     },
     {
-      "name": "INSECURE_REPOSITORY",
-      "displayName": "INSECURE_REPOSITORY",
-      "description": "Mark the image stream as an insecure repository",
-      "value": "false"
-    },
-    {
       "name": "IMAGE_PULL_SECRET",
       "displayName": "IMAGE_PULL_SECRET",
       "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
+    },
+    {
+      "name": "INSECURE_REPOSITORY",
+      "displayName": "INSECURE_REPOSITORY",
+      "description": "Mark the image stream as an insecure repository",
+      "value": "false"
     },
     {
       "name": "MEMORY_MIN",

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-private-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-private-hosted.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ml.json
+++ b/omar/openshift/templates/apps/omar-ml.json
@@ -309,6 +309,11 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-oldmar-app.json
+++ b/omar/openshift/templates/apps/omar-oldmar-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-oldmar-app.json
+++ b/omar/openshift/templates/apps/omar-oldmar-app.json
@@ -197,6 +197,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-oldmar-app.json
+++ b/omar/openshift/templates/apps/omar-oldmar-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-oldmar-app.json
+++ b/omar/openshift/templates/apps/omar-oldmar-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-oms-app.json
+++ b/omar/openshift/templates/apps/omar-oms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-oms-app.json
+++ b/omar/openshift/templates/apps/omar-oms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-oms-app.json
+++ b/omar/openshift/templates/apps/omar-oms-app.json
@@ -223,6 +223,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-oms-app.json
+++ b/omar/openshift/templates/apps/omar-oms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-pki-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-pki-proxy-app.json
@@ -196,6 +196,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-pki-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-pki-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-pki-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-pki-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-pki-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-pki-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-reachback-app.json
+++ b/omar/openshift/templates/apps/omar-reachback-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-reachback-app.json
+++ b/omar/openshift/templates/apps/omar-reachback-app.json
@@ -197,6 +197,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-reachback-app.json
+++ b/omar/openshift/templates/apps/omar-reachback-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-reachback-app.json
+++ b/omar/openshift/templates/apps/omar-reachback-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-services-monitor-app.json
+++ b/omar/openshift/templates/apps/omar-services-monitor-app.json
@@ -191,6 +191,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-services-monitor-app.json
+++ b/omar/openshift/templates/apps/omar-services-monitor-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-services-monitor-app.json
+++ b/omar/openshift/templates/apps/omar-services-monitor-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-services-monitor-app.json
+++ b/omar/openshift/templates/apps/omar-services-monitor-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-sqs-stager-app.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-app.json
@@ -227,6 +227,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-sqs-stager-app.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-sqs-stager-app.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-sqs-stager-app.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
@@ -227,6 +227,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-cucumber.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-sqs-stager-slow.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-slow.json
@@ -227,6 +227,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-sqs-stager-slow.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-slow.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-sqs-stager-slow.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-slow.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-sqs-stager-slow.json
+++ b/omar/openshift/templates/apps/omar-sqs-stager-slow.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-stager-app.json
+++ b/omar/openshift/templates/apps/omar-stager-app.json
@@ -226,6 +226,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-stager-app.json
+++ b/omar/openshift/templates/apps/omar-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-stager-app.json
+++ b/omar/openshift/templates/apps/omar-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-stager-app.json
+++ b/omar/openshift/templates/apps/omar-stager-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-streetview-app.json
+++ b/omar/openshift/templates/apps/omar-streetview-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -171,6 +171,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-streetview-app.json
+++ b/omar/openshift/templates/apps/omar-streetview-app.json
@@ -351,9 +351,14 @@
                 "imagePullPolicy": "Always"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
+            "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "terminationGracePeriodSeconds": 30,
-            "dnsPolicy": "ClusterFirst",
             "securityContext": {}
           }
         }

--- a/omar/openshift/templates/apps/omar-streetview-app.json
+++ b/omar/openshift/templates/apps/omar-streetview-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-streetview-app.json
+++ b/omar/openshift/templates/apps/omar-streetview-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-superoverlay-app.json
+++ b/omar/openshift/templates/apps/omar-superoverlay-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-superoverlay-app.json
+++ b/omar/openshift/templates/apps/omar-superoverlay-app.json
@@ -197,6 +197,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-superoverlay-app.json
+++ b/omar/openshift/templates/apps/omar-superoverlay-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-superoverlay-app.json
+++ b/omar/openshift/templates/apps/omar-superoverlay-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-twofishes.json
+++ b/omar/openshift/templates/apps/omar-twofishes.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-twofishes.json
+++ b/omar/openshift/templates/apps/omar-twofishes.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-twofishes.json
+++ b/omar/openshift/templates/apps/omar-twofishes.json
@@ -193,6 +193,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-twofishes.json
+++ b/omar/openshift/templates/apps/omar-twofishes.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-ui-app.json
+++ b/omar/openshift/templates/apps/omar-ui-app.json
@@ -201,6 +201,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-ui-app.json
+++ b/omar/openshift/templates/apps/omar-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-app.json
+++ b/omar/openshift/templates/apps/omar-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-app.json
+++ b/omar/openshift/templates/apps/omar-ui-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-ui-ods-app.json
+++ b/omar/openshift/templates/apps/omar-ui-ods-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-ods-app.json
+++ b/omar/openshift/templates/apps/omar-ui-ods-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-ui-ods-app.json
+++ b/omar/openshift/templates/apps/omar-ui-ods-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-ods-app.json
+++ b/omar/openshift/templates/apps/omar-ui-ods-app.json
@@ -207,6 +207,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-ui-proto.json
+++ b/omar/openshift/templates/apps/omar-ui-proto.json
@@ -69,13 +69,6 @@
       "value": "false"
     },
     {
-      "name": "IMAGE_PULL_SECRET",
-      "displayName": "IMAGE_PULL_SECRET",
-      "description": "The name of the secret to use for pulling docker images from an external registry",
-      "required": true,
-      "value": ""
-    },
-    {
       "name": "MEMORY_MIN",
       "displayName": "MEMORY_MIN",
       "description": "Minimum memory for this app to have",

--- a/omar/openshift/templates/apps/omar-ui-proto.json
+++ b/omar/openshift/templates/apps/omar-ui-proto.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-proto.json
+++ b/omar/openshift/templates/apps/omar-ui-proto.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-ui-proto.json
+++ b/omar/openshift/templates/apps/omar-ui-proto.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-upload-app.json
+++ b/omar/openshift/templates/apps/omar-upload-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-upload-app.json
+++ b/omar/openshift/templates/apps/omar-upload-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-upload-app.json
+++ b/omar/openshift/templates/apps/omar-upload-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-upload-app.json
+++ b/omar/openshift/templates/apps/omar-upload-app.json
@@ -217,6 +217,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-video-ui.json
+++ b/omar/openshift/templates/apps/omar-video-ui.json
@@ -209,6 +209,11 @@
                 "name": "${IMAGE_PULL_SECRET}"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-video-ui.json
+++ b/omar/openshift/templates/apps/omar-video-ui.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-video-ui.json
+++ b/omar/openshift/templates/apps/omar-video-ui.json
@@ -69,13 +69,6 @@
       "value": "false"
     },
     {
-      "name": "IMAGE_PULL_SECRET",
-      "displayName": "IMAGE_PULL_SECRET",
-      "description": "The name of the secret to use for pulling docker images from an external registry",
-      "required": true,
-      "value": ""
-    },
-    {
       "name": "MEMORY_MIN",
       "displayName": "MEMORY_MIN",
       "description": "Minimum memory for this app to have",
@@ -202,11 +195,6 @@
                   }
                 },
                 "terminationMessagePath": "/dev/termination-log"
-              }
-            ],
-            "imagePullSecrets": [
-              {
-                "name": "${IMAGE_PULL_SECRET}"
               }
             ],
             "imagePullSecrets": [

--- a/omar/openshift/templates/apps/omar-video-ui.json
+++ b/omar/openshift/templates/apps/omar-video-ui.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-video-ui.json
+++ b/omar/openshift/templates/apps/omar-video-ui.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-volume-cleanup.json
+++ b/omar/openshift/templates/apps/omar-volume-cleanup.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -171,6 +171,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-volume-cleanup.json
+++ b/omar/openshift/templates/apps/omar-volume-cleanup.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-volume-cleanup.json
+++ b/omar/openshift/templates/apps/omar-volume-cleanup.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-volume-cleanup.json
+++ b/omar/openshift/templates/apps/omar-volume-cleanup.json
@@ -388,6 +388,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-wcs-app.json
+++ b/omar/openshift/templates/apps/omar-wcs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wcs-app.json
+++ b/omar/openshift/templates/apps/omar-wcs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-wcs-app.json
+++ b/omar/openshift/templates/apps/omar-wcs-app.json
@@ -223,6 +223,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-wcs-app.json
+++ b/omar/openshift/templates/apps/omar-wcs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-web-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-web-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -66,6 +66,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-web-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-web-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-web-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-web-proxy-app.json
@@ -215,6 +215,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-web-proxy-app.json
+++ b/omar/openshift/templates/apps/omar-web-proxy-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wfs-app.json
+++ b/omar/openshift/templates/apps/omar-wfs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wfs-app.json
+++ b/omar/openshift/templates/apps/omar-wfs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-wfs-app.json
+++ b/omar/openshift/templates/apps/omar-wfs-app.json
@@ -210,6 +210,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-wfs-app.json
+++ b/omar/openshift/templates/apps/omar-wfs-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wms-app.json
+++ b/omar/openshift/templates/apps/omar-wms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wms-app.json
+++ b/omar/openshift/templates/apps/omar-wms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/omar-wms-app.json
+++ b/omar/openshift/templates/apps/omar-wms-app.json
@@ -210,6 +210,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-wms-app.json
+++ b/omar/openshift/templates/apps/omar-wms-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wmts-app.json
+++ b/omar/openshift/templates/apps/omar-wmts-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wmts-app.json
+++ b/omar/openshift/templates/apps/omar-wmts-app.json
@@ -197,6 +197,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/omar-wmts-app.json
+++ b/omar/openshift/templates/apps/omar-wmts-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/omar-wmts-app.json
+++ b/omar/openshift/templates/apps/omar-wmts-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/ossim-isa-service.json
+++ b/omar/openshift/templates/apps/ossim-isa-service.json
@@ -224,6 +224,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/ossim-isa-service.json
+++ b/omar/openshift/templates/apps/ossim-isa-service.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/ossim-isa-service.json
+++ b/omar/openshift/templates/apps/ossim-isa-service.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/ossim-isa-service.json
+++ b/omar/openshift/templates/apps/ossim-isa-service.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/ossim-jpip-server.json
+++ b/omar/openshift/templates/apps/ossim-jpip-server.json
@@ -202,6 +202,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/ossim-jpip-server.json
+++ b/omar/openshift/templates/apps/ossim-jpip-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -66,6 +66,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/ossim-jpip-server.json
+++ b/omar/openshift/templates/apps/ossim-jpip-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/ossim-jpip-server.json
+++ b/omar/openshift/templates/apps/ossim-jpip-server.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/rabbitmq.json
+++ b/omar/openshift/templates/apps/rabbitmq.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/rabbitmq.json
+++ b/omar/openshift/templates/apps/rabbitmq.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/rabbitmq.json
+++ b/omar/openshift/templates/apps/rabbitmq.json
@@ -199,6 +199,11 @@
                 "terminationMessagePath": "/dev/termination-log"
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/rabbitmq.json
+++ b/omar/openshift/templates/apps/rabbitmq.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -52,6 +52,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/tlv-app.json
+++ b/omar/openshift/templates/apps/tlv-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "quay.io/radiantsolutions"
+      "value": "nexus-docker-public-hosted.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/tlv-app.json
+++ b/omar/openshift/templates/apps/tlv-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-group.ossim.io"
+      "value": "nexus-docker-private-group.ossim.io"
     },
     {
       "description": "",
@@ -59,6 +59,13 @@
       "name": "IMAGE_NAME",
       "displayName": "IMAGE_NAME",
       "description": "The name of the docker image to pull",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "IMAGE_PULL_SECRET",
+      "displayName": "IMAGE_PULL_SECRET",
+      "description": "The name of the secret to use for pulling docker images from an external registry",
       "required": true,
       "value": ""
     },

--- a/omar/openshift/templates/apps/tlv-app.json
+++ b/omar/openshift/templates/apps/tlv-app.json
@@ -210,6 +210,11 @@
                 ]
               }
             ],
+            "imagePullSecrets": [
+              {
+                "name": "${IMAGE_PULL_SECRET}"
+              }
+            ],
             "dnsPolicy": "ClusterFirst",
             "restartPolicy": "Always",
             "securityContext": {},

--- a/omar/openshift/templates/apps/tlv-app.json
+++ b/omar/openshift/templates/apps/tlv-app.json
@@ -12,7 +12,7 @@
       "description": "",
       "displayName": "",
       "name": "DOCKER_IMAGE_REPO",
-      "value": "nexus-docker-public-hosted.ossim.io"
+      "value": "nexus-docker-public-group.ossim.io"
     },
     {
       "description": "",

--- a/omar/openshift/templates/apps/zookeeper-app.yml
+++ b/omar/openshift/templates/apps/zookeeper-app.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: ALLOW_ANONYMOUS_LOGIN
               value: 'yes'
-          image: quay.io/radiantsolutions/zookeeper
+          image: nexus-docker-public-hosted.ossim.io/zookeeper
           imagePullPolicy: Always
           name: zookeeper
           ports:

--- a/omar/openshift/templates/apps/zookeeper-app.yml
+++ b/omar/openshift/templates/apps/zookeeper-app.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: ALLOW_ANONYMOUS_LOGIN
               value: 'yes'
-          image: nexus-docker-public-group.ossim.io/zookeeper
+          image: nexus-docker-private-group.ossim.io/zookeeper
           imagePullPolicy: Always
           name: zookeeper
           ports:

--- a/omar/openshift/templates/apps/zookeeper-app.yml
+++ b/omar/openshift/templates/apps/zookeeper-app.yml
@@ -62,6 +62,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: registry-creds
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/omar/openshift/templates/apps/zookeeper-app.yml
+++ b/omar/openshift/templates/apps/zookeeper-app.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: ALLOW_ANONYMOUS_LOGIN
               value: 'yes'
-          image: nexus-docker-public-hosted.ossim.io/zookeeper
+          image: nexus-docker-public-group.ossim.io/zookeeper
           imagePullPolicy: Always
           name: zookeeper
           ports:

--- a/omar/openshift/templates/apps/zookeeper-template.yaml
+++ b/omar/openshift/templates/apps/zookeeper-template.yaml
@@ -49,7 +49,7 @@ objects:
             - env:
                 - name: ALLOW_ANONYMOUS_LOGIN
                   value: 'yes'
-              image: quay.io/radiantsolutions/zookeeper
+              image: nexus-docker-public-hosted.ossim.io/zookeeper
               imagePullPolicy: Always
               name: zookeeper
               ports:

--- a/omar/openshift/templates/apps/zookeeper-template.yaml
+++ b/omar/openshift/templates/apps/zookeeper-template.yaml
@@ -49,7 +49,7 @@ objects:
             - env:
                 - name: ALLOW_ANONYMOUS_LOGIN
                   value: 'yes'
-              image: nexus-docker-public-hosted.ossim.io/zookeeper
+              image: nexus-docker-public-group.ossim.io/zookeeper
               imagePullPolicy: Always
               name: zookeeper
               ports:

--- a/omar/openshift/templates/apps/zookeeper-template.yaml
+++ b/omar/openshift/templates/apps/zookeeper-template.yaml
@@ -49,7 +49,7 @@ objects:
             - env:
                 - name: ALLOW_ANONYMOUS_LOGIN
                   value: 'yes'
-              image: nexus-docker-public-group.ossim.io/zookeeper
+              image: nexus-docker-private-group.ossim.io/zookeeper
               imagePullPolicy: Always
               name: zookeeper
               ports:

--- a/omar/openshift/templates/apps/zookeeper-template.yaml
+++ b/omar/openshift/templates/apps/zookeeper-template.yaml
@@ -65,6 +65,8 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
           dnsPolicy: ClusterFirst
+          imagePullSecrets:
+            - name: registry-creds
           restartPolicy: Always
           schedulerName: default-scheduler
           securityContext: {}

--- a/openshift/opendistro/proxy/omar-web-proxy-app.yml
+++ b/openshift/opendistro/proxy/omar-web-proxy-app.yml
@@ -31,7 +31,7 @@ spec:
         deploymentconfig: omar-web-proxy-app
     spec:
       containers:
-      - image: nexus-docker-public-hosted.ossim.io/omar-web-proxy-app:latest
+      - image: nexus-docker-private-group.ossim.io/omar-web-proxy-app:latest
         imagePullPolicy: Always
         name: omar-web-proxy-app
         ports:

--- a/openshift/opendistro/proxy/omar-web-proxy-app.yml
+++ b/openshift/opendistro/proxy/omar-web-proxy-app.yml
@@ -31,7 +31,7 @@ spec:
         deploymentconfig: omar-web-proxy-app
     spec:
       containers:
-      - image: quay.io/radiantsolutions/omar-web-proxy-app:latest
+      - image: nexus-docker-public-hosted.ossim.io/omar-web-proxy-app:latest
         imagePullPolicy: Always
         name: omar-web-proxy-app
         ports:

--- a/openshift/opendistro/proxy/omar-web-proxy-app.yml
+++ b/openshift/opendistro/proxy/omar-web-proxy-app.yml
@@ -48,6 +48,8 @@ spec:
         - mountPath: /etc/httpd/conf.d
           name: volume-gqbjf
       dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: registry-creds
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}


### PR DESCRIPTION
With the migration of our Docker images off of Quay and onto Nexus, I updated the Openshift templates to pull from Nexus.